### PR TITLE
Fix full row detection bug in detect_full_rows

### DIFF
--- a/bichitetris.py
+++ b/bichitetris.py
@@ -145,9 +145,9 @@ def get_next_piece():
 def detect_full_rows():
     global board
     full_rows = []
-    for row in board:
+    for index, row in enumerate(board):
         if 0 not in row:
-            full_rows.insert(0, board.index(row))
+            full_rows.insert(0, index)
     return full_rows
 
 


### PR DESCRIPTION
## Summary
- Correct full row detection to use enumerate and avoid incorrect indices when multiple identical rows exist.

## Testing
- `python -m py_compile bichitetris.py`
- `python - <<'PY'
import ast
source=open('bichitetris.py').read()
module=ast.parse(source)
func=None
for node in module.body:
    if isinstance(node, ast.FunctionDef) and node.name=='detect_full_rows':
        func=node
        break
mod=ast.Module(body=[func], type_ignores=[])
code=compile(mod, filename='<ast>', mode='exec')
namespace={}
exec(code, namespace)
namespace['board']=[[1]*10,[1]*10,[0]*10]
print(namespace['detect_full_rows']())
namespace['board']=[[1]*10,[1]*10,[1]*10,[0]*10]
print(namespace['detect_full_rows']())
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e0e0c2e8c832c9558c68d454e4d85